### PR TITLE
Updated pyproject.toml for pySigma 0.11.X support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pysigma = ">=0.9.8, <0.11.0"
+pysigma = ">=0.9.8, <0.12.0"
 regex = "^2023.12.25"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Change pySigma pinned version in `pyproject.toml` for pySigma v0.11.X support with backend